### PR TITLE
versionコマンドの追加

### DIFF
--- a/atcoder_helper/scripts/executor.py
+++ b/atcoder_helper/scripts/executor.py
@@ -5,6 +5,7 @@ import os
 import sys
 import traceback
 
+from atcoder_helper._version import __version__
 from atcoder_helper.services import errors as service_errors
 from atcoder_helper.services.atcoder_helper_config import AtCoderHelperConfigService
 from atcoder_helper.services.atcoder_helper_config import (
@@ -247,6 +248,14 @@ class Executor:
             if args.verbose:
                 print(traceback.format_exc())
             sys.exit(1)
+
+    def version_handler(self, args: argparse.Namespace) -> None:
+        """現在のバージョンを表示する.
+
+        Args:
+            args (argparse.Namespace): 引数
+        """
+        print(__version__)
 
 
 def get_default_executor() -> Executor:

--- a/atcoder_helper/scripts/parser.py
+++ b/atcoder_helper/scripts/parser.py
@@ -21,6 +21,7 @@ def get_root_parser() -> argparse.ArgumentParser:
     _set_fetch_parser(root_subparsers.add_parser("fetch"))
     _set_task_pasrer(root_subparsers.add_parser("task"))
     _set_config_parser(root_subparsers.add_parser("config"))
+    _set_version_parser(root_subparsers.add_parser("version"))
 
     return root_parser
 
@@ -100,3 +101,7 @@ def _set_config_parser(parser_config: argparse.ArgumentParser) -> None:
         handler=Executor.config_use_handler, parser=parser_config_use
     )
     parser_config_use.add_argument("language")
+
+
+def _set_version_parser(parser_version: argparse.ArgumentParser) -> None:
+    parser_version.set_defaults(handler=Executor.version_handler, parser=parser_version)

--- a/integration_test/integration_test.sh
+++ b/integration_test/integration_test.sh
@@ -93,6 +93,11 @@ function can_task_create() {
     echo "OK"
 }
 
+function can_show_version(){
+    echo "バージョンコマンドを実行できるかを確認する"
+    test "$($CMD version)" == "DUMMY"
+}
+
 function main() {
     cd integration_test
 
@@ -104,6 +109,7 @@ function main() {
 
     # 初期設定
     installed
+    can_show_version
     can_logout
     can_show_auth_status
     can_config_init


### PR DESCRIPTION
 - versionコマンドの追加
` $atcoder_helper version  `
を行うことで現在のatcoder_helperのバージョンを表示することができます。