### PR TITLE
mypyのscopeを指定した

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ lint:
 	flake8
 
 type-check:
-	mypy --install-types --non-interactive .
+	mypy --install-types --non-interactive atcoder_helper tests
 
 test:
 	pytest -v tests


### PR DESCRIPTION
# 概要

mypyがlocalでのみ失敗する現象が発生していた。
調査したところ、build package内で型チェックエラーが発生していた。ここは配布用生成物置き場なので、型チェックは不要である。
そこで、mypyのcheck対象としてatcoder_helperとtests ディレクトリを明示的に指定し、buildディレクトリを含めないようにした

# 確認方法

local で `make` が通る