### PR TITLE
auth loginをintegration testに含める

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,3 +43,6 @@ jobs:
           python-version: "3.10"
       - run: pip install -r requirements.txt
       - run: make integration
+        env:
+          ATCODER_HELPER_NAME: ${{ secrets.ATCODER_HELPER_NAME }}
+          ATCODER_HELPER_PASSWORD: ${{ secrets.ATCODER_HELPER_PASSWORD }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,9 @@ jobs:
           python-version: "3.10"
       - run: pip install -r requirements.txt
       - run: make integration
+        env:
+          ATCODER_HELPER_NAME: ${{ secrets.ATCODER_HELPER_NAME }}
+          ATCODER_HELPER_PASSWORD: ${{ secrets.ATCODER_HELPER_PASSWORD }}
   release:
     needs: ["lint", "test", "integration"]
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ atcoder_helper.egg-info
 /dist
 /.mypy_cache
 /.pytest_cache
+
+/integration_test/secret.env

--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,8 @@ uninstall:
 integration: uninstall install
 	integration_test/integration_test.sh
 
-
 build:
 	python setup.py sdist
 	python setup.py bdist_wheel
-
-upload-test: build
-	twine upload --repository testpypi dist/*
 
 .PHONY: lint test lint type-check check-all integration build upload-test uninstall install

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ PyPI: <https://pypi.org/project/atcoder-helper/>
 
 ## 開発
 
+- [開発を始める](./docs/getting_started.md)
 - [リポジトリ構造](./docs/about_repository_structure.md)
 - [プログラム構造](./docs/about_program_structure.md)
 - [設計上の決定](./docs/decisions_on_architecturing.md)

--- a/atcoder_helper/scripts/executor.py
+++ b/atcoder_helper/scripts/executor.py
@@ -55,8 +55,8 @@ class Executor:
 
     def auth_login_handler(self, args: argparse.Namespace) -> None:
         """ログインする."""
-        name = input("name:")
-        password = getpass.getpass("password:")
+        name = args.username if args.username else input("name:")
+        password = args.password if args.password else getpass.getpass("password:")
         try:
             self._auth_service.login(name, password)
         except service_errors.AlreadyLoggedIn:

--- a/atcoder_helper/scripts/parser.py
+++ b/atcoder_helper/scripts/parser.py
@@ -35,6 +35,8 @@ def _set_auth_parser(parser_auth: argparse.ArgumentParser) -> None:
     parser_auth_login.set_defaults(
         handler=Executor.auth_login_handler, parser=parser_auth_login
     )
+    parser_auth_login.add_argument("--username")
+    parser_auth_login.add_argument("--password")
 
     parser_auth_logout = parser_auth_subparsers.add_parser("logout")
     parser_auth_logout.set_defaults(

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,24 @@
+# 開発を始める
+
+## 事前準備
+
+atcoderにloginできる検証用のusernameとpasswordを `integration_test/secret.env` に以下の形式で記載してください。
+
+
+```env
+ATCODER_HELPER_NAME=your_user_name
+ATCODER_HELPER_PASSWORD=your_password
+```
+
+このファイルは`.gitignore`されており、remoteにアップロードされることはありません。
+この情報はlocalでintegration_testを実施するために必要となります。
+
+
+## 開発環境
+
+vscodeのremote container環境で開発されています。
+
+
+## localでのチェック
+
+`make` を実行すると、諸々のコードチェック・テストなどが走るようになっています。詳細はMakefileを参照。

--- a/integration_test/integration_test.sh
+++ b/integration_test/integration_test.sh
@@ -18,6 +18,11 @@ function can_config_init() {
     $CMD config init
 }
 
+function can_login() {
+    echo "atcoder_helper auth loginができることを確認する"
+    $CMD auth login --username $ATCODER_HELPER_NAME --password $ATCODER_HELPER_PASSWORD
+}
+
 function can_logout() {
     echo "logoutがfailしない"
     $CMD auth logout
@@ -101,6 +106,10 @@ function can_show_version(){
 function main() {
     cd integration_test
 
+    if [ -e secret.env ]; then
+        source secret.env
+    fi
+
     rm -rf workdir
     mkdir workdir
     cd workdir
@@ -110,6 +119,7 @@ function main() {
     # 初期設定
     installed
     can_show_version
+    can_login
     can_logout
     can_show_auth_status
     can_config_init

--- a/tests/scripts/test_executor.py
+++ b/tests/scripts/test_executor.py
@@ -72,10 +72,10 @@ def test_auth_login_handler(
         mock.patch("getpass.getpass", return_value=password),
     ):
         if should_succeed:
-            sut.auth_login_handler(_get_default_namespace())
+            sut.auth_login_handler(_get_default_namespace(username="", password=""))
         else:
             with pytest.raises(SystemExit) as e:
-                sut.auth_login_handler(_get_default_namespace())
+                sut.auth_login_handler(_get_default_namespace(username="", password=""))
             assert e.value.code == 1
 
 


### PR DESCRIPTION
# 概要

auth loginがintegration testに含められていないかったので、含めるように改修した。
それに伴い、開発を始めるにあたり必要な下準備が追加されたので、docsにその旨を記載した。
また、repositoryに追加の秘匿情報を注入した

# 確認方法
- [x] localで`make integration` できる
- [x] CIが通る。
- [x] logに秘匿情報が露出していないことを確認
   - https://github.com/yuchiki/atcoder_helper/runs/8206232727?check_suite_focus=true