### PR TITLE
integration testをdocker化した

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,7 @@ jobs:
       - uses: actions/setup-python@v3
         with:
           python-version: "3.10"
+      - run: pip install -r requirements.txt
       - run: make build
       - run: make install
   integration:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,14 +34,19 @@ jobs:
           python-version: "3.10"
       - run: pip install -r requirements.txt
       - run: make test
-  integration:
+  build-and-install:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
           python-version: "3.10"
-      - run: pip install -r requirements.txt
+      - run: make build
+      - run: make install
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
       - run: make integration
         env:
           ATCODER_HELPER_NAME: ${{ secrets.ATCODER_HELPER_NAME }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,8 +11,17 @@ jobs:
         with:
           python-version: "3.10"
       - run: pip install -r requirements.txt
-      - run: mypy --install-types --non-interactive .
       - run: make lint
+  type-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+      - run: pip install -r requirements.txt
+      - run: mypy --install-types --non-interactive .
+      - run: make type-check
   test:
     runs-on: ubuntu-latest
     steps:
@@ -22,20 +31,25 @@ jobs:
           python-version: "3.10"
       - run: pip install -r requirements.txt
       - run: make test
-  integration:
+  build-and-install:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
           python-version: "3.10"
-      - run: pip install -r requirements.txt
+      - run: make build
+      - run: make install
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
       - run: make integration
         env:
           ATCODER_HELPER_NAME: ${{ secrets.ATCODER_HELPER_NAME }}
           ATCODER_HELPER_PASSWORD: ${{ secrets.ATCODER_HELPER_PASSWORD }}
   release:
-    needs: ["lint", "test", "integration"]
+    needs: ["lint", "type-check", "test", "build-and-install", "integration"]
     runs-on: ubuntu-latest
     steps:
       - id: get_tag

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,6 +38,7 @@ jobs:
       - uses: actions/setup-python@v3
         with:
           python-version: "3.10"
+      - run: pip install -r requirements.txt
       - run: make build
       - run: make install
   integration:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-check-all: test lint type-check integration
+check-all: test lint type-check build integration
 
 lint:
 	isort .

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ install: build
 uninstall:
 	pip uninstall -y atcoder_helper
 
-integration: uninstall install
-	integration_test/integration_test.sh
+integration:
+	integration_test/integration_test_entry.sh
 
 build:
 	python setup.py sdist

--- a/integration_test/Dockerfile
+++ b/integration_test/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.10
+
+RUN mkdir work
+WORKDIR work
+
+COPY requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+
+COPY MANIFEST.in MANIFEST.in
+COPY README.md README.md
+COPY setup.py setup.py
+
+COPY integration_test integration_test
+
+COPY atcoder_helper atcoder_helper
+
+RUN ls
+
+RUN python setup.py sdist
+RUN python setup.py bdist_wheel
+
+
+RUN pip install dist/atcoder_helper-DUMMY-py3-none-any.whl
+RUN which atcoder_helper

--- a/integration_test/integration_test.sh
+++ b/integration_test/integration_test.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-set -eux
+# このスクリプトは integration_test_entry.sh 経由でdockerコンテナの中で動かすことが想定されている。
+
+set -eu
 
 CMD="atcoder_helper --verbose"
 

--- a/integration_test/integration_test.sh
+++ b/integration_test/integration_test.sh
@@ -2,7 +2,7 @@
 
 # このスクリプトは integration_test_entry.sh 経由でdockerコンテナの中で動かすことが想定されている。
 
-set -eu
+set -eux
 
 CMD="atcoder_helper --verbose"
 

--- a/integration_test/integration_test_entry.sh
+++ b/integration_test/integration_test_entry.sh
@@ -3,4 +3,8 @@ set eux
 IMAGE_TAG=atcoder_helper_integration_environment
 
 docker build -f integration_test/Dockerfile -t $IMAGE_TAG .
-docker run $IMAGE_TAG integration_test/integration_test.sh
+docker run \
+    --env ATCODER_HELPER_NAME=${ATCODER_HELPER_NAME:-""} \
+    --env ATCODER_HELPER_PASSWORD=${ATCODER_HELPER_PASSWORD:-""} \
+    $IMAGE_TAG \
+    integration_test/integration_test.sh

--- a/integration_test/integration_test_entry.sh
+++ b/integration_test/integration_test_entry.sh
@@ -1,0 +1,6 @@
+set eux
+
+IMAGE_TAG=atcoder_helper_integration_environment
+
+docker build -f integration_test/Dockerfile -t $IMAGE_TAG .
+docker run $IMAGE_TAG integration_test/integration_test.sh


### PR DESCRIPTION
# 概要

ローカルでintegration testを行うとき、開発環境の既存の状態によらず実施できるように、integration testをdocker化した。


# 変更点
- integration_test.shはdocker container内で実行するように変更し、`make integration_test`で dockerファイルでは integration_test_entry.shを呼び出すようにした。
- integration_test_entry.shは、dockerコンテナ内で integration_test.shを実行する。
- buildにまつわるMakefileターゲットと、ci/releaseのworkflowを追加した
  -  今まで通り、integration test内でbuildも実行されている。しかし、makefileターゲット上では分離されて、integration が buildを呼び出しているのが非自明になったため 