### PR TITLE
injectorで依存を整理する

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,7 +30,7 @@
 				"python.formatting.provider": "black",
 				"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
 				"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
-				"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+				"python.linting.mypyPath": "/usr/local/bin/mypy",
 				"python.linting.mypyEnabled": true,
 				"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
 				"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ lint:
 	flake8
 
 type-check:
-	mypy --install-types --non-interactive atcoder_helper tests
+	/usr/local/bin/mypy --install-types --non-interactive atcoder_helper tests
 
 test:
 	pytest -v tests

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ lint:
 	flake8
 
 type-check:
-	/usr/local/bin/mypy --install-types --non-interactive atcoder_helper tests
+	sh -c 'if [ -e /usr/local/bin/mypy ]; then /usr/local/bin/mypy --install-types --non-interactive atcoder_helper tests; else mypy --install-types --non-interactive atcoder_helper tests; fi'
 
 test:
 	pytest -v tests

--- a/atcoder_helper/dependency.py
+++ b/atcoder_helper/dependency.py
@@ -1,23 +1,57 @@
 """依存性注入モジュール."""
 
+import os
+from typing import Final
 from typing import Type
 from typing import TypeVar
 
 from injector import Binder
 from injector import Injector
 
-from atcoder_helper.usecases.atcoder_helper_config import AtCoderHelperConfigUsecase
-from atcoder_helper.usecases.atcoder_helper_config import (
-    get_default_atcoder_helper_config_usecase,
+import atcoder_helper
+from atcoder_helper.infrastructure.atcoder_helper_config_repo import ConfigRepository
+from atcoder_helper.infrastructure.atcoder_helper_config_repo import (
+    ConfigRepositoryImpl,
 )
+from atcoder_helper.infrastructure.atcoder_logged_in_session_repo import (
+    AtCoderLoggedInSessionRepository,
+)
+from atcoder_helper.infrastructure.atcoder_logged_in_session_repo import (
+    AtCoderLoggedInSessionRepositoryImpl,
+)
+from atcoder_helper.infrastructure.atcoder_test_case_repo import (
+    AtCoderTestCaseRepository,
+)
+from atcoder_helper.infrastructure.atcoder_test_case_repo import (
+    AtCoderTestCaseRepositoryImpl,
+)
+from atcoder_helper.infrastructure.local_test_case_repo import LocalTestCaseRepository
+from atcoder_helper.infrastructure.local_test_case_repo import (
+    LocalTestCaseRepositoryImpl,
+)
+from atcoder_helper.infrastructure.logged_in_session_repo import (
+    LoggedInSessionRepository,
+)
+from atcoder_helper.infrastructure.logged_in_session_repo import (
+    LoggedInSessionRepositoryImpl,
+)
+from atcoder_helper.infrastructure.login_status_repo import LoginStatusRepo
+from atcoder_helper.infrastructure.login_status_repo import LoginStatusRepoImpl
+from atcoder_helper.infrastructure.task_config_repo import TaskConfigRepository
+from atcoder_helper.infrastructure.task_config_repo import TaskConfigRepositoryImpl
+from atcoder_helper.usecases.atcoder_helper_config import AtCoderHelperConfigInteractor
+from atcoder_helper.usecases.atcoder_helper_config import AtCoderHelperConfigUsecase
+from atcoder_helper.usecases.auth import AuthInteractor
 from atcoder_helper.usecases.auth import AuthUsecase
-from atcoder_helper.usecases.auth import get_default_auth_usecase
+from atcoder_helper.usecases.execute_test import ControllerBuilder
+from atcoder_helper.usecases.execute_test import ControllerBuilderImpl
+from atcoder_helper.usecases.execute_test import ExecuteTestInteractor
 from atcoder_helper.usecases.execute_test import ExecuteTestUsecase
-from atcoder_helper.usecases.execute_test import get_default_execute_test_usecase
+from atcoder_helper.usecases.fetch_task import FetchTaskInteractor
 from atcoder_helper.usecases.fetch_task import FetchTaskUsecase
-from atcoder_helper.usecases.fetch_task import get_default_fetch_task_usecase
+from atcoder_helper.usecases.init_task import InitTaskDirInteractor
 from atcoder_helper.usecases.init_task import InitTaskDirUsecase
-from atcoder_helper.usecases.init_task import get_default_init_task_dir_usecase
+from atcoder_helper.usecases.util import get_atcoder_helper_config_filepath
 
 T = TypeVar("T")
 
@@ -34,24 +68,69 @@ class Dependency:
     @staticmethod
     def config(binder: Binder) -> None:
         """依存性の注入を行う."""
-        binder.bind(
-            AuthUsecase, get_default_auth_usecase  # type: ignore[type-abstract]
-        )
+        binder.bind(AuthUsecase, AuthInteractor)  # type: ignore[type-abstract]
+
         binder.bind(
             AtCoderHelperConfigUsecase,  # type: ignore[type-abstract]
-            get_default_atcoder_helper_config_usecase,
+            lambda: AtCoderHelperConfigInteractor(
+                config_repo=ConfigRepositoryImpl(get_atcoder_helper_config_filepath()),
+                default_config_repo=ConfigRepositoryImpl(
+                    os.path.join(
+                        atcoder_helper.__path__[0],
+                        "default_configs",
+                        "default_config.yaml",
+                    )
+                ),
+            ),
         )
         binder.bind(
             ExecuteTestUsecase,  # type: ignore[type-abstract]
-            get_default_execute_test_usecase,
+            ExecuteTestInteractor,
         )
         binder.bind(
             FetchTaskUsecase,  # type: ignore[type-abstract]
-            get_default_fetch_task_usecase,
+            FetchTaskInteractor,
         )
         binder.bind(
             InitTaskDirUsecase,  # type: ignore[type-abstract]
-            get_default_init_task_dir_usecase,
+            InitTaskDirInteractor,
+        )
+
+        binder.bind(
+            ControllerBuilder, ControllerBuilderImpl  # type: ignore[type-abstract]
+        )
+
+        binder.bind(
+            ConfigRepository,  # type: ignore[type-abstract]
+            lambda: ConfigRepositoryImpl(get_atcoder_helper_config_filepath()),
+        )
+        binder.bind(
+            AtCoderLoggedInSessionRepository,  # type: ignore[type-abstract]
+            AtCoderLoggedInSessionRepositoryImpl,
+        )
+        binder.bind(
+            AtCoderTestCaseRepository,  # type: ignore[type-abstract]
+            AtCoderTestCaseRepositoryImpl,
+        )
+        binder.bind(
+            LocalTestCaseRepository,  # type: ignore[type-abstract]
+            lambda: LocalTestCaseRepositoryImpl("testcases.yaml"),
+        )
+
+        default_session_file: Final[str] = os.path.join(
+            os.path.expanduser("~"), ".atcoder_helper", "session", "session_dump.pkl"
+        )
+        binder.bind(
+            LoggedInSessionRepository,  # type: ignore[type-abstract]
+            lambda: LoggedInSessionRepositoryImpl(default_session_file),
+        )
+        binder.bind(LoginStatusRepo, LoginStatusRepoImpl)  # type: ignore[type-abstract]
+
+        default_filename = ".atcoder_helper_task_config.yaml"
+
+        binder.bind(
+            TaskConfigRepository,  # type: ignore[type-abstract]
+            lambda: TaskConfigRepositoryImpl(default_filename),
         )
 
     def resolve(self, cls: Type[T]) -> T:

--- a/atcoder_helper/dependency.py
+++ b/atcoder_helper/dependency.py
@@ -1,0 +1,59 @@
+"""依存性注入モジュール."""
+
+from typing import Type
+from typing import TypeVar
+
+from injector import Binder
+from injector import Injector
+
+from atcoder_helper.usecases.atcoder_helper_config import AtCoderHelperConfigUsecase
+from atcoder_helper.usecases.atcoder_helper_config import (
+    get_default_atcoder_helper_config_usecase,
+)
+from atcoder_helper.usecases.auth import AuthUsecase
+from atcoder_helper.usecases.auth import get_default_auth_usecase
+from atcoder_helper.usecases.execute_test import ExecuteTestUsecase
+from atcoder_helper.usecases.execute_test import get_default_execute_test_usecase
+from atcoder_helper.usecases.fetch_task import FetchTaskUsecase
+from atcoder_helper.usecases.fetch_task import get_default_fetch_task_usecase
+from atcoder_helper.usecases.init_task import InitTaskDirUsecase
+from atcoder_helper.usecases.init_task import get_default_init_task_dir_usecase
+
+T = TypeVar("T")
+
+
+class Dependency:
+    """依存性の注入を管理する."""
+
+    _injector: Injector
+
+    def __init__(self) -> None:
+        """init."""
+        self._injector = Injector(self.__class__.config)
+
+    @staticmethod
+    def config(binder: Binder) -> None:
+        """依存性の注入を行う."""
+        binder.bind(
+            AuthUsecase, get_default_auth_usecase  # type: ignore[type-abstract]
+        )
+        binder.bind(
+            AtCoderHelperConfigUsecase,  # type: ignore[type-abstract]
+            get_default_atcoder_helper_config_usecase,
+        )
+        binder.bind(
+            ExecuteTestUsecase,  # type: ignore[type-abstract]
+            get_default_execute_test_usecase,
+        )
+        binder.bind(
+            FetchTaskUsecase,  # type: ignore[type-abstract]
+            get_default_fetch_task_usecase,
+        )
+        binder.bind(
+            InitTaskDirUsecase,  # type: ignore[type-abstract]
+            get_default_init_task_dir_usecase,
+        )
+
+    def resolve(self, cls: Type[T]) -> T:
+        """Class のインスタンスを生成する."""
+        return self._injector.get(cls)

--- a/atcoder_helper/dependency.py
+++ b/atcoder_helper/dependency.py
@@ -56,6 +56,18 @@ from atcoder_helper.usecases.util import get_atcoder_helper_config_filepath
 T = TypeVar("T")
 
 
+testcase_filename = "testcases.yaml"
+default_session_file: Final[str] = os.path.join(
+    os.path.expanduser("~"), ".atcoder_helper", "session", "session_dump.pkl"
+)
+default_task_config_filename = ".atcoder_helper_task_config.yaml"
+default_config_filename = os.path.join(
+    atcoder_helper.__path__[0],
+    "default_configs",
+    "default_config.yaml",
+)
+
+
 class Dependency:
     """依存性の注入を管理する."""
 
@@ -74,13 +86,7 @@ class Dependency:
             AtCoderHelperConfigUsecase,  # type: ignore[type-abstract]
             lambda: AtCoderHelperConfigInteractor(
                 config_repo=ConfigRepositoryImpl(get_atcoder_helper_config_filepath()),
-                default_config_repo=ConfigRepositoryImpl(
-                    os.path.join(
-                        atcoder_helper.__path__[0],
-                        "default_configs",
-                        "default_config.yaml",
-                    )
-                ),
+                default_config_repo=ConfigRepositoryImpl(default_config_filename),
             ),
         )
         binder.bind(
@@ -114,23 +120,18 @@ class Dependency:
         )
         binder.bind(
             LocalTestCaseRepository,  # type: ignore[type-abstract]
-            lambda: LocalTestCaseRepositoryImpl("testcases.yaml"),
+            lambda: LocalTestCaseRepositoryImpl(testcase_filename),
         )
 
-        default_session_file: Final[str] = os.path.join(
-            os.path.expanduser("~"), ".atcoder_helper", "session", "session_dump.pkl"
-        )
         binder.bind(
             LoggedInSessionRepository,  # type: ignore[type-abstract]
             lambda: LoggedInSessionRepositoryImpl(default_session_file),
         )
         binder.bind(LoginStatusRepo, LoginStatusRepoImpl)  # type: ignore[type-abstract]
 
-        default_filename = ".atcoder_helper_task_config.yaml"
-
         binder.bind(
             TaskConfigRepository,  # type: ignore[type-abstract]
-            lambda: TaskConfigRepositoryImpl(default_filename),
+            lambda: TaskConfigRepositoryImpl(default_task_config_filename),
         )
 
     def resolve(self, cls: Type[T]) -> T:

--- a/atcoder_helper/infrastructure/atcoder_helper_config_repo.py
+++ b/atcoder_helper/infrastructure/atcoder_helper_config_repo.py
@@ -9,7 +9,6 @@ from atcoder_helper.entities.atcoder_helper_config import AtCoderHelperConfig
 from atcoder_helper.infrastructure.errors import ParseError
 from atcoder_helper.infrastructure.errors import ReadError
 from atcoder_helper.infrastructure.errors import WriteError
-from atcoder_helper.usecases.util import get_atcoder_helper_config_filepath
 
 
 class ConfigRepository(Protocol):
@@ -38,11 +37,6 @@ class ConfigRepository(Protocol):
         Raises:
             WriteError: 書き込みに失敗した
         """
-
-
-def get_default_config_repository() -> ConfigRepository:
-    """ConfigRepositoryの標準実装を返す."""
-    return ConfigRepositoryImpl(get_atcoder_helper_config_filepath())
 
 
 class ConfigRepositoryImpl:

--- a/atcoder_helper/infrastructure/atcoder_logged_in_session_repo.py
+++ b/atcoder_helper/infrastructure/atcoder_logged_in_session_repo.py
@@ -32,15 +32,6 @@ class AtCoderLoggedInSessionRepository(Protocol):
         """
 
 
-def get_default_atcoder_session_repository() -> AtCoderLoggedInSessionRepository:
-    """AtCoderLoggedInSessionRepositoryのデフォルト実装を返す.
-
-    Returns:
-        AtCoderLoggedInSessionRepository: デフォルト実装
-    """
-    return AtCoderLoggedInSessionRepositoryImpl()
-
-
 class AtCoderLoggedInSessionRepositoryImpl:
     """atcoder からlogin済みのセッションを取得するrepository."""
 

--- a/atcoder_helper/infrastructure/atcoder_test_case_repo.py
+++ b/atcoder_helper/infrastructure/atcoder_test_case_repo.py
@@ -33,15 +33,6 @@ class AtCoderTestCaseRepository(Protocol):
         """
 
 
-def get_default_atcoder_test_case_repository() -> AtCoderTestCaseRepository:
-    """AtCoderTestCaseRepositoryのデフォルト実装を作成する.
-
-    Returns:
-        AtCoderTestCaseRepository: デフォルト実装
-    """
-    return AtCoderTestCaseRepositoryImpl()
-
-
 class AtCoderTestCaseRepositoryImpl:
     """AtCoderからテストケースを取得するリポジトリ."""
 

--- a/atcoder_helper/infrastructure/local_test_case_repo.py
+++ b/atcoder_helper/infrastructure/local_test_case_repo.py
@@ -35,12 +35,6 @@ class LocalTestCaseRepository(Protocol):
         """
 
 
-def get_default_local_test_case_repository() -> LocalTestCaseRepository:
-    """TestCaseRepositoryの標準実装を返す."""
-    default_testcase_file = "testcases.yaml"
-    return LocalTestCaseRepositoryImpl(default_testcase_file)
-
-
 class LocalTestCaseRepositoryImpl:
     """テストケースの永続化を行う."""
 

--- a/atcoder_helper/infrastructure/logged_in_session_repo.py
+++ b/atcoder_helper/infrastructure/logged_in_session_repo.py
@@ -2,7 +2,6 @@
 
 import os
 import pickle
-from typing import Final
 from typing import Protocol
 from typing import cast
 
@@ -45,18 +44,6 @@ class LoggedInSessionRepository(Protocol):
         Raises:
             WriteError: _
         """
-
-
-def get_default_session_repository() -> LoggedInSessionRepository:
-    """LoggedInSessionRepositoryの標準実装を返す.
-
-    Returns:
-        LoggedInSessionRepositoryImpl: 標準実装
-    """
-    default_session_file: Final[str] = os.path.join(
-        os.path.expanduser("~"), ".atcoder_helper", "session", "session_dump.pkl"
-    )
-    return LoggedInSessionRepositoryImpl(default_session_file)
 
 
 class LoggedInSessionRepositoryImpl:

--- a/atcoder_helper/infrastructure/login_status_repo.py
+++ b/atcoder_helper/infrastructure/login_status_repo.py
@@ -22,15 +22,6 @@ class LoginStatusRepo(Protocol):
         """
 
 
-def get_default_login_status_repo() -> LoginStatusRepo:
-    """LoginStatusRepoの標準実装を返す.
-
-    Returns:
-        LoginStatusRepo: 標準実装
-    """
-    return LoginStatusRepoImpl()
-
-
 class LoginStatusRepoImpl:
     """login情報を取得するrepository."""
 

--- a/atcoder_helper/infrastructure/task_config_repo.py
+++ b/atcoder_helper/infrastructure/task_config_repo.py
@@ -52,12 +52,6 @@ class TaskConfigRepository(Protocol):
         """
 
 
-def get_default_task_config_repository() -> TaskConfigRepository:
-    """TaskConfigRepositoryの標準実装."""
-    default_filename = ".atcoder_helper_task_config.yaml"
-    return TaskConfigRepositoryImpl(default_filename)
-
-
 class TaskConfigRepositoryImpl:
     """TaskConfigを取得する.
 

--- a/atcoder_helper/program_executor.py
+++ b/atcoder_helper/program_executor.py
@@ -32,13 +32,6 @@ class ProgramExecutor(Protocol):
         """
 
 
-def get_default_program_executor(
-    build_command: List[str], run_command: List[str]
-) -> ProgramExecutor:
-    """ProgramExecutorRepoの標準実装を返す."""
-    return ProgramExecutorRepoImpl(build_command, run_command)
-
-
 class ProgramExecutorRepoImpl:
     """プログラム実行のためのロジックを集約させるためのリポジトリ実装."""
 

--- a/atcoder_helper/scripts/controller.py
+++ b/atcoder_helper/scripts/controller.py
@@ -10,17 +10,10 @@ from injector import inject
 from atcoder_helper._version import __version__
 from atcoder_helper.usecases import errors as usecase_errors
 from atcoder_helper.usecases.atcoder_helper_config import AtCoderHelperConfigUsecase
-from atcoder_helper.usecases.atcoder_helper_config import (
-    get_default_atcoder_helper_config_usecase,
-)
 from atcoder_helper.usecases.auth import AuthUsecase
-from atcoder_helper.usecases.auth import get_default_auth_usecase
 from atcoder_helper.usecases.execute_test import ExecuteTestUsecase
-from atcoder_helper.usecases.execute_test import get_default_execute_test_usecase
 from atcoder_helper.usecases.fetch_task import FetchTaskUsecase
-from atcoder_helper.usecases.fetch_task import get_default_fetch_task_usecase
 from atcoder_helper.usecases.init_task import InitTaskDirUsecase
-from atcoder_helper.usecases.init_task import get_default_init_task_dir_usecase
 
 
 class Controller:
@@ -259,14 +252,3 @@ class Controller:
             args (argparse.Namespace): 引数
         """
         print(__version__)
-
-
-def get_default_controller() -> Controller:
-    """標準Controllerを返す."""
-    return Controller(
-        auth_usecase=get_default_auth_usecase(),
-        atcoder_helper_config_usecase=(get_default_atcoder_helper_config_usecase()),
-        execute_test_usecase=get_default_execute_test_usecase(),
-        fetch_task_usecase=get_default_fetch_task_usecase(),
-        init_task_dir_usecase=get_default_init_task_dir_usecase(),
-    )

--- a/atcoder_helper/scripts/controller.py
+++ b/atcoder_helper/scripts/controller.py
@@ -5,6 +5,8 @@ import os
 import sys
 import traceback
 
+from injector import inject
+
 from atcoder_helper._version import __version__
 from atcoder_helper.usecases import errors as usecase_errors
 from atcoder_helper.usecases.atcoder_helper_config import AtCoderHelperConfigUsecase
@@ -30,6 +32,7 @@ class Controller:
     _fetch_task_usecase: FetchTaskUsecase
     _init_task_dir_usecase: InitTaskDirUsecase
 
+    @inject
     def __init__(
         self,
         auth_usecase: AuthUsecase,

--- a/atcoder_helper/scripts/main.py
+++ b/atcoder_helper/scripts/main.py
@@ -1,12 +1,14 @@
 """atcoder_helperコマンドのエントリポイント."""
 
-from atcoder_helper.scripts.controller import get_default_controller
+from atcoder_helper.dependency import Dependency
+from atcoder_helper.scripts.controller import Controller
 from atcoder_helper.scripts.parser import get_root_parser
 
 
 def main() -> None:
     """entrypoint."""
-    controller = get_default_controller()
+    injector = Dependency()
+    controller = injector.resolve(Controller)
 
     root_parser = get_root_parser()
     args = root_parser.parse_args()

--- a/atcoder_helper/usecases/atcoder_helper_config.py
+++ b/atcoder_helper/usecases/atcoder_helper_config.py
@@ -1,20 +1,14 @@
 """デフォルト言語を変更する."""
 
 
-import os
 from typing import Dict
 from typing import Protocol
 
-import atcoder_helper
+from injector import inject
+
 from atcoder_helper.entities.atcoder_helper_config import LanguageConfig
 from atcoder_helper.infrastructure import errors as repository_errors
 from atcoder_helper.infrastructure.atcoder_helper_config_repo import ConfigRepository
-from atcoder_helper.infrastructure.atcoder_helper_config_repo import (
-    ConfigRepositoryImpl,
-)
-from atcoder_helper.infrastructure.atcoder_helper_config_repo import (
-    get_default_config_repository,
-)
 from atcoder_helper.usecases.errors import ConfigAccessError
 from atcoder_helper.usecases.errors import UndefinedLanguage
 
@@ -60,28 +54,13 @@ class AtCoderHelperConfigUsecase(Protocol):
         """
 
 
-def get_default_atcoder_helper_config_usecase() -> AtCoderHelperConfigUsecase:
-    """AtCoderHelperConfigUsecaseの標準実装を返す.
-
-    Returns:
-        AtCoderHelperConfigUsecase:
-    """
-    return AtCoderHelperConfigInteractor(
-        config_repo=get_default_config_repository(),
-        default_config_repo=ConfigRepositoryImpl(
-            os.path.join(
-                atcoder_helper.__path__[0], "default_configs", "default_config.yaml"
-            )
-        ),
-    )
-
-
 class AtCoderHelperConfigInteractor:
     """AtCoderHelperConfigを操作する Usecase."""
 
     _config_repo: ConfigRepository
     _default_config_repo: ConfigRepository
 
+    @inject
     def __init__(
         self, config_repo: ConfigRepository, default_config_repo: ConfigRepository
     ):

--- a/atcoder_helper/usecases/auth.py
+++ b/atcoder_helper/usecases/auth.py
@@ -3,23 +3,16 @@
 
 from typing import Protocol
 
+from injector import inject
+
 import atcoder_helper.infrastructure.errors as repository_error
 from atcoder_helper.infrastructure.atcoder_logged_in_session_repo import (
     AtCoderLoggedInSessionRepository,
 )
-from atcoder_helper.infrastructure.atcoder_logged_in_session_repo import (
-    get_default_atcoder_session_repository,
-)
 from atcoder_helper.infrastructure.logged_in_session_repo import (
     LoggedInSessionRepository,
 )
-from atcoder_helper.infrastructure.logged_in_session_repo import (
-    get_default_session_repository,
-)
 from atcoder_helper.infrastructure.login_status_repo import LoginStatusRepo
-from atcoder_helper.infrastructure.login_status_repo import (
-    get_default_login_status_repo,
-)
 from atcoder_helper.usecases.errors import AtcoderAccessError
 from atcoder_helper.usecases.errors import ConfigAccessError
 
@@ -58,15 +51,6 @@ class AuthUsecase(Protocol):
         """
 
 
-def get_default_auth_usecase() -> AuthUsecase:
-    """AuthUsecaseの標準実装を返す."""
-    return AuthInteractor(
-        atcoder_session_repo=(get_default_atcoder_session_repository()),
-        local_session_repo=(get_default_session_repository()),
-        login_status_repo=get_default_login_status_repo(),
-    )
-
-
 class AuthInteractor:
     """auth を扱うサービス."""
 
@@ -74,6 +58,7 @@ class AuthInteractor:
     _local_session_repo: LoggedInSessionRepository
     _login_status_repo: LoginStatusRepo
 
+    @inject
     def __init__(
         self,
         atcoder_session_repo: AtCoderLoggedInSessionRepository,

--- a/atcoder_helper/usecases/fetch_task.py
+++ b/atcoder_helper/usecases/fetch_task.py
@@ -3,27 +3,17 @@ from typing import Optional
 from typing import Protocol
 from typing import Tuple
 
+from injector import inject
+
 from atcoder_helper.infrastructure import errors as repository_error
 from atcoder_helper.infrastructure.atcoder_test_case_repo import (
     AtCoderTestCaseRepository,
 )
-from atcoder_helper.infrastructure.atcoder_test_case_repo import (
-    get_default_atcoder_test_case_repository,
-)
 from atcoder_helper.infrastructure.local_test_case_repo import LocalTestCaseRepository
-from atcoder_helper.infrastructure.local_test_case_repo import (
-    get_default_local_test_case_repository,
-)
 from atcoder_helper.infrastructure.logged_in_session_repo import (
     LoggedInSessionRepository,
 )
-from atcoder_helper.infrastructure.logged_in_session_repo import (
-    get_default_session_repository,
-)
 from atcoder_helper.infrastructure.task_config_repo import TaskConfigRepository
-from atcoder_helper.infrastructure.task_config_repo import (
-    get_default_task_config_repository,
-)
 from atcoder_helper.usecases.errors import AtcoderAccessError
 from atcoder_helper.usecases.errors import ConfigAccessError
 
@@ -48,20 +38,6 @@ class FetchTaskUsecase(Protocol):
         """
 
 
-def get_default_fetch_task_usecase() -> FetchTaskUsecase:
-    """FetchTaskUsecaseの標準実装を返す.
-
-    Returns:
-        FetchTaskUsecase:
-    """
-    return FetchTaskInteractor(
-        task_config_repo=get_default_task_config_repository(),
-        test_case_repo=get_default_local_test_case_repository(),
-        session_repo=get_default_session_repository(),
-        atcoder_testcase_repo=(get_default_atcoder_test_case_repository()),
-    )
-
-
 class FetchTaskInteractor:
     """atcoderサイトからテストケースを取得するサービス."""
 
@@ -70,6 +46,7 @@ class FetchTaskInteractor:
     _session_repo: LoggedInSessionRepository
     _atcoder_testcase_repo: AtCoderTestCaseRepository
 
+    @inject
     def __init__(
         self,
         task_config_repo: TaskConfigRepository,

--- a/atcoder_helper/usecases/init_task.py
+++ b/atcoder_helper/usecases/init_task.py
@@ -2,18 +2,14 @@
 from typing import Optional
 from typing import Protocol
 
+from injector import inject
+
 import atcoder_helper.infrastructure.errors as repo_errors
 from atcoder_helper.entities.atcoder_task_config import TaskConfig
 from atcoder_helper.infrastructure.atcoder_helper_config_repo import ConfigRepository
-from atcoder_helper.infrastructure.atcoder_helper_config_repo import (
-    get_default_config_repository,
-)
 from atcoder_helper.infrastructure.errors import ParseError
 from atcoder_helper.infrastructure.errors import ReadError
 from atcoder_helper.infrastructure.task_config_repo import TaskConfigRepository
-from atcoder_helper.infrastructure.task_config_repo import (
-    get_default_task_config_repository,
-)
 from atcoder_helper.usecases.errors import ConfigAccessError
 
 
@@ -34,24 +30,13 @@ class InitTaskDirUsecase(Protocol):
         """
 
 
-def get_default_init_task_dir_usecase() -> InitTaskDirUsecase:
-    """InitTaskDirUsecaseの標準実装を返す.
-
-    Returns:
-        InitTaskDirUsecase: _description_
-    """
-    return InitTaskDirInteractor(
-        atcoder_helper_config_repo=get_default_config_repository(),
-        task_config_repo=get_default_task_config_repository(),
-    )
-
-
 class InitTaskDirInteractor:
     """TaskDirectoryを初期化するサービス."""
 
     _atcoder_helper_config_repo: ConfigRepository
     _task_config_repo: TaskConfigRepository
 
+    @inject
     def __init__(
         self,
         atcoder_helper_config_repo: ConfigRepository,

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,10 +6,11 @@ black
 isort
 flake8-docstrings
 hacking
-mypy
+mypy >= 0.990
 pytest
 pytest-cov
 twine
 wheel
 mock
 pydantic
+injector

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,14 @@ setuptools.setup(
     url=URL,
     download_url=URL,
     python_requires=">=3.10",
-    install_requires=["colorama", "beautifulsoup4", "requests", "pyyaml", "pydantic"],
+    install_requires=[
+        "colorama",
+        "beautifulsoup4",
+        "requests",
+        "pyyaml",
+        "pydantic",
+        "injector",
+    ],
     entry_points={"console_scripts": "atcoder_helper=atcoder_helper.scripts.main:main"},
     packages=setuptools.find_packages(),
     classifiers=[

--- a/tests/usecases/test_execute_test.py
+++ b/tests/usecases/test_execute_test.py
@@ -84,9 +84,11 @@ def test_execute_test(
         task_config_repo_mock=task_config_repo_mock,
         test_case_repo_mock=test_case_repo_mock,
         controller_builder=mock.MagicMock(
-            return_value=mock.MagicMock(
-                build=build_mock,
-                execute=execute_mock,
+            build=mock.MagicMock(
+                return_value=mock.MagicMock(
+                    build=build_mock,
+                    execute=execute_mock,
+                )
             )
         ),
     )


### PR DESCRIPTION
# 概要

## 依存性注入をinjector という DI library に任せた

このファイルが依存関係を記憶していて
https://github.com/yuchiki/atcoder_helper/blob/bf1dd11df6cb416e33f37cd062475889010b1d52/atcoder_helper/dependency.py#L59


このようにinstantiateされる:
https://github.com/yuchiki/atcoder_helper/pull/36/files#diff-d49320212d003a9dfb544d0aaf068e8e2a741491d8be13525859778256a8aab7R11

依存ライブラリの依存ライブラリまで連鎖的に依存性が注入されてinstance が生成される

## mypy のバージョンについて

デフォルトで py-utilsのpyを見に行ってしまうようにpathが生えている。
しかし、pipで新しいversionのmypyを入れないと動かない
そのため正しい方のmypyを見に行くように `make type-check` を変更している


# 後続の変更

次のPRでファイルの置き方を以下のように変更すればatcoder_helperをonion architectureに近づける作業は終わり

- usecases/hogeUsecase -> application/usecases/hogeUsecase
- usecases/hogeInteractor -> application/interactors/hogeInteractor
- infrastructure/hogeRepository -> application/repositories/hogeRepository
- scripts -> adapter/scripts
- infrastructure -> adapter/infrastructure